### PR TITLE
Create config.json

### DIFF
--- a/.github/fiware/config.json
+++ b/.github/fiware/config.json
@@ -1,0 +1,19 @@
+{
+    "enabler": "CanisMajor - FIWARE DLT Adaptor",
+    "chapter": "core",
+    "academy": "",
+    "readthedocs": "https://fiware.github.io/CanisMajor/",
+    "helpdesk": "",
+    "coveralls": "",
+    "github": ["FIWARE/CanisMajor"],
+    "dockerregistry": ["hub.docker.com"],
+    "docker": ["singhhp10691/canismajor"],
+    "email": "harpreet.singh@fiware.org",
+    "status": "incubating",
+    "compose": "",
+    "exclude": [""],
+    "stackexchange": [""],
+    "unit-test": "",
+    "smoke-test": "",
+    "dockerfile": "https://github.com/FIWARE/CanisMajor/blob/master/Dockerfile"
+}


### PR DESCRIPTION
The FIWARE Foundation need a simple JSON file available in a standard location in each repo to be able to continue to make FIWARE Releases and improve the degree of cross-product integration testing that can occur. This change has been agreed by the TSC and has been added to the contribution requirements.

Please suggest or amend values where known.