### PR TITLE
fix: ngsild compliant context

### DIFF
--- a/docs/canis-major-integration-guide.md
+++ b/docs/canis-major-integration-guide.md
@@ -82,12 +82,12 @@ To retrieve the available entity types in the context broker run the following c
 
 ```shell
 curl -iX GET 'http://localhost:1026/ngsi-ld/v1/types' \
-    -H 'Link: <https://raw.githubusercontent.com/smart-data-models/dataModel.DistributedLedgerTech/master/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' \
+    -H 'Link: <https://smart-data-models.github.io/dataModel.DistributedLedgerTech/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' \
     -H 'NGSILD-Tenant: orion'
 ```
 The command returns the following response, demonstrating the available entity types in the Context Broker:
 ```json
-"@context": "https://raw.githubusercontent.com/smart-data-models/dataModel.DistributedLedgerTech/master/context.jsonld",
+"@context": "https://smart-data-models.github.io/dataModel.DistributedLedgerTech/context.jsonld",
 "id": "urn:ngsi-ld:EntityTypeList:d77ccfa0-b3cd-11ef-ae1b-0242ac120005",
 "type": "EntityTypeList",
 "typeList": ["DLTtxReceipt"]
@@ -159,7 +159,7 @@ To retrieve specific DLT transaction receipts from the the context broker, we'll
 
 ```shell
 curl -iX GET 'http://localhost:1026/ngsi-ld/v1/entities/?type=DLTtxReceipt&q=refEntity%3D%3D%22urn%3Angsi-ld%3ABuilding%3Awarehouse001%22&attrs=TxReceipts' \
-    -H 'Link: <https://raw.githubusercontent.com/smart-data-models/dataModel.DistributedLedgerTech/master/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' \
+    -H 'Link: <https://smart-data-models.github.io/dataModel.DistributedLedgerTech/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' \
     -H 'NGSILD-Tenant: orion'
 ```
 
@@ -167,7 +167,7 @@ The output will be similar to the following json response:
 
 ```json
 {
-    "@context": "https://raw.githubusercontent.com/smart-data-models/dataModel.DistributedLedgerTech/master/context.jsonld",
+    "@context": "https://smart-data-models.github.io/dataModel.DistributedLedgerTech/context.jsonld",
     "id": "urn:ngsi-ld:dlttxreceipt:0xa46d2e3b190d36fbb8af5d0a1c212d8036cf007e6ec4d1309904e052d25e5499",
     "type": "DLTtxReceipt",
     "TxReceipts": {

--- a/src/main/java/org/fiware/canismajor/mapping/TxReceiptMapper.java
+++ b/src/main/java/org/fiware/canismajor/mapping/TxReceiptMapper.java
@@ -26,10 +26,10 @@ public interface TxReceiptMapper {
 
 	ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-	// the transaction index will be appended as a id
+	// the transaction index will be appended as an id
 	String ID_TEMPLATE = "urn:ngsi-ld:dlttxreceipt:%s";
 	String ENTITY_TYPE = "DLTtxReceipt";
-	String CONTEXT = "https://raw.githubusercontent.com/smart-data-models/dataModel.DistributedLedgerTech/master/context.jsonld";
+	String CONTEXT = "https://smart-data-models.github.io/dataModel.DistributedLedgerTech/context.jsonld";
 	String TX_RECEIPTS_KEY = "TxReceipts";
 	String REF_ENTITY_KEY = "refEntity";
 	String RETRIEVAL_QUERY_KEY = "retrievalQuery";


### PR DESCRIPTION
The context URL `https://raw.githubusercontent.com/smart-data-models/dataModel.DistributedLedgerTech/master/context.jsonld` returns a `text/plain` Content-Type, which will be rejected by some context brokers.

![image](https://github.com/user-attachments/assets/bb2cce12-ed6f-462f-890b-f04b11765acf)


So I changed the context URL to `https://smart-data-models.github.io/dataModel.DistributedLedgerTech/context.jsonld`, which contains the same data but returns an `application/ld+json` Content-Type.

![image](https://github.com/user-attachments/assets/6ce2ff90-e629-4de6-a177-ca4ba2ef8fe8)
